### PR TITLE
feat: Add public IConditionEvaluator interface for standalone condition evaluation

### DIFF
--- a/TriasDev.Templify.Tests/ConditionEvaluatorTests.cs
+++ b/TriasDev.Templify.Tests/ConditionEvaluatorTests.cs
@@ -310,5 +310,40 @@ public class ConditionEvaluatorTests
         Assert.Throws<ArgumentNullException>(() => _evaluator.CreateContext((string)null!));
     }
 
+    [Fact]
+    public async Task EvaluateAsync_WithNullExpression_ThrowsArgumentNullException()
+    {
+        Dictionary<string, object> data = new() { ["Key"] = "Value" };
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _evaluator.EvaluateAsync(null!, data));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithNullDictionary_ThrowsArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _evaluator.EvaluateAsync("IsActive", (Dictionary<string, object>)null!));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithNullJsonData_ThrowsArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _evaluator.EvaluateAsync("IsActive", (string)null!));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithNullContext_ThrowsArgumentNullException()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(() => _evaluator.EvaluateAsync("IsActive", (IEvaluationContext)null!));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithCancelledToken_ThrowsOperationCanceledException()
+    {
+        Dictionary<string, object> data = new() { ["IsActive"] = true };
+        CancellationToken cancelledToken = new(canceled: true);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => _evaluator.EvaluateAsync("IsActive", data, cancelledToken));
+    }
+
     #endregion
 }

--- a/TriasDev.Templify/Conditionals/ConditionEvaluator.cs
+++ b/TriasDev.Templify/Conditionals/ConditionEvaluator.cs
@@ -87,20 +87,23 @@ public sealed class ConditionEvaluator : IConditionEvaluator
     }
 
     /// <inheritdoc/>
-    public Task<bool> EvaluateAsync(string expression, Dictionary<string, object> data)
+    public Task<bool> EvaluateAsync(string expression, Dictionary<string, object> data, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         return Task.FromResult(Evaluate(expression, data));
     }
 
     /// <inheritdoc/>
-    public Task<bool> EvaluateAsync(string expression, string jsonData)
+    public Task<bool> EvaluateAsync(string expression, string jsonData, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         return Task.FromResult(Evaluate(expression, jsonData));
     }
 
     /// <inheritdoc/>
-    public Task<bool> EvaluateAsync(string expression, IEvaluationContext context)
+    public Task<bool> EvaluateAsync(string expression, IEvaluationContext context, CancellationToken cancellationToken = default)
     {
+        cancellationToken.ThrowIfCancellationRequested();
         return Task.FromResult(Evaluate(expression, context));
     }
 

--- a/TriasDev.Templify/Conditionals/IConditionEvaluator.cs
+++ b/TriasDev.Templify/Conditionals/IConditionEvaluator.cs
@@ -86,28 +86,34 @@ public interface IConditionEvaluator
     /// </summary>
     /// <param name="expression">The expression to evaluate.</param>
     /// <param name="data">The data dictionary containing variables to resolve.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task that resolves to true if the condition is met; otherwise, false.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="expression"/> or <paramref name="data"/> is null.</exception>
-    Task<bool> EvaluateAsync(string expression, Dictionary<string, object> data);
+    /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+    Task<bool> EvaluateAsync(string expression, Dictionary<string, object> data, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously evaluates a conditional expression against JSON data.
     /// </summary>
     /// <param name="expression">The expression to evaluate.</param>
     /// <param name="jsonData">A JSON string representing the data object.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task that resolves to true if the condition is met; otherwise, false.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="expression"/> or <paramref name="jsonData"/> is null.</exception>
     /// <exception cref="System.Text.Json.JsonException">Thrown when JSON is invalid or root is not an object.</exception>
-    Task<bool> EvaluateAsync(string expression, string jsonData);
+    /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+    Task<bool> EvaluateAsync(string expression, string jsonData, CancellationToken cancellationToken = default);
 
     /// <summary>
     /// Asynchronously evaluates a conditional expression using a pre-created evaluation context.
     /// </summary>
     /// <param name="expression">The expression to evaluate.</param>
     /// <param name="context">The evaluation context containing variable data.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
     /// <returns>A task that resolves to true if the condition is met; otherwise, false.</returns>
     /// <exception cref="ArgumentNullException">Thrown when <paramref name="expression"/> or <paramref name="context"/> is null.</exception>
-    Task<bool> EvaluateAsync(string expression, IEvaluationContext context);
+    /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+    Task<bool> EvaluateAsync(string expression, IEvaluationContext context, CancellationToken cancellationToken = default);
 
     #endregion
 


### PR DESCRIPTION
## Summary
- Add `IConditionEvaluator` interface in `TriasDev.Templify.Conditionals` namespace
- Add `ConditionEvaluator` implementation wrapping internal `ConditionalEvaluator`
- Support Dictionary, JSON string, and `IEvaluationContext` inputs
- Include sync and async methods (`EvaluateAsync` wraps sync for API compatibility)
- Add `CreateContext` methods for batch evaluation scenarios
- Add null parameter validation with `ArgumentNullException`
- Add 26 unit tests covering all methods and edge cases

Closes #24

## Test plan
- [x] All 716 existing tests pass
- [x] 26 new tests for `ConditionEvaluator` pass
- [x] Null parameter validation tested
- [x] JSON and Dictionary inputs tested
- [x] Context creation and batch evaluation tested