### PR TITLE
feat: Add public IConditionContext interface for batch condition evaluations

### DIFF
--- a/TriasDev.Templify.Tests/ConditionContextTests.cs
+++ b/TriasDev.Templify.Tests/ConditionContextTests.cs
@@ -1,0 +1,284 @@
+// Copyright (c) 2025 TriasDev GmbH & Co. KG
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+using System.Text.Json;
+using TriasDev.Templify.Conditionals;
+
+namespace TriasDev.Templify.Tests;
+
+/// <summary>
+/// Tests for the public <see cref="IConditionContext"/> interface and <see cref="ConditionContext"/> class.
+/// </summary>
+public class ConditionContextTests
+{
+    private readonly ConditionEvaluator _evaluator = new();
+
+    #region CreateConditionContext with Dictionary
+
+    [Fact]
+    public void CreateConditionContext_WithDictionary_ReturnsValidContext()
+    {
+        Dictionary<string, object> data = new()
+        {
+            ["IsActive"] = true,
+            ["Count"] = 5
+        };
+
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        Assert.NotNull(context);
+    }
+
+    [Fact]
+    public void CreateConditionContext_WithNullDictionary_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => _evaluator.CreateConditionContext((Dictionary<string, object>)null!));
+    }
+
+    #endregion
+
+    #region CreateConditionContext with JSON
+
+    [Fact]
+    public void CreateConditionContext_WithJson_ReturnsValidContext()
+    {
+        string json = """{"IsActive": true, "Count": 5}""";
+
+        IConditionContext context = _evaluator.CreateConditionContext(json);
+
+        Assert.NotNull(context);
+    }
+
+    [Fact]
+    public void CreateConditionContext_WithNullJson_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => _evaluator.CreateConditionContext((string)null!));
+    }
+
+    [Fact]
+    public void CreateConditionContext_WithInvalidJson_ThrowsJsonException()
+    {
+        string invalidJson = "{ invalid json }";
+
+        Assert.Throws<JsonException>(() => _evaluator.CreateConditionContext(invalidJson));
+    }
+
+    #endregion
+
+    #region Evaluate
+
+    [Fact]
+    public void Evaluate_WithTrueBoolean_ReturnsTrue()
+    {
+        Dictionary<string, object> data = new() { ["IsActive"] = true };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        bool result = context.Evaluate("IsActive");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Evaluate_WithFalseBoolean_ReturnsFalse()
+    {
+        Dictionary<string, object> data = new() { ["IsActive"] = false };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        bool result = context.Evaluate("IsActive");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Evaluate_WithMissingVariable_ReturnsFalse()
+    {
+        Dictionary<string, object> data = new();
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        bool result = context.Evaluate("MissingVar");
+
+        Assert.False(result);
+    }
+
+    [Fact]
+    public void Evaluate_WithComparison_ReturnsCorrectResult()
+    {
+        Dictionary<string, object> data = new() { ["Count"] = 5 };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        Assert.True(context.Evaluate("Count > 3"));
+        Assert.True(context.Evaluate("Count = 5"));
+        Assert.False(context.Evaluate("Count < 3"));
+    }
+
+    [Fact]
+    public void Evaluate_WithStringComparison_ReturnsCorrectResult()
+    {
+        Dictionary<string, object> data = new() { ["Status"] = "Active" };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        bool result = context.Evaluate("Status = \"Active\"");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Evaluate_WithLogicalOperators_ReturnsCorrectResult()
+    {
+        Dictionary<string, object> data = new()
+        {
+            ["IsEnabled"] = true,
+            ["HasAccess"] = true
+        };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        Assert.True(context.Evaluate("IsEnabled and HasAccess"));
+        Assert.True(context.Evaluate("IsEnabled or HasAccess"));
+    }
+
+    [Fact]
+    public void Evaluate_WithNegation_ReturnsCorrectResult()
+    {
+        Dictionary<string, object> data = new() { ["IsDisabled"] = false };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        bool result = context.Evaluate("not IsDisabled");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public void Evaluate_WithNestedPath_ReturnsCorrectResult()
+    {
+        Dictionary<string, object> data = new()
+        {
+            ["Customer"] = new Dictionary<string, object>
+            {
+                ["Name"] = "John",
+                ["IsActive"] = true
+            }
+        };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        Assert.True(context.Evaluate("Customer.IsActive"));
+        Assert.True(context.Evaluate("Customer.Name = \"John\""));
+    }
+
+    [Fact]
+    public void Evaluate_WithNullExpression_ThrowsArgumentNullException()
+    {
+        Dictionary<string, object> data = new() { ["Key"] = "Value" };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        Assert.Throws<ArgumentNullException>(() => context.Evaluate(null!));
+    }
+
+    [Fact]
+    public void Evaluate_BatchEvaluation_ReusesContext()
+    {
+        Dictionary<string, object> data = new()
+        {
+            ["IsActive"] = true,
+            ["Count"] = 5,
+            ["Status"] = "Active"
+        };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        // Evaluate multiple expressions against the same context
+        Assert.True(context.Evaluate("IsActive"));
+        Assert.True(context.Evaluate("Count > 3"));
+        Assert.True(context.Evaluate("Status = \"Active\""));
+        Assert.True(context.Evaluate("IsActive and Count > 0"));
+    }
+
+    #endregion
+
+    #region EvaluateAsync
+
+    [Fact]
+    public async Task EvaluateAsync_WithTrueBoolean_ReturnsTrue()
+    {
+        Dictionary<string, object> data = new() { ["IsActive"] = true };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        bool result = await context.EvaluateAsync("IsActive");
+
+        Assert.True(result);
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithComparison_ReturnsCorrectResult()
+    {
+        Dictionary<string, object> data = new() { ["Count"] = 10 };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        Assert.True(await context.EvaluateAsync("Count > 5"));
+        Assert.False(await context.EvaluateAsync("Count < 5"));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithNullExpression_ThrowsArgumentNullException()
+    {
+        Dictionary<string, object> data = new() { ["Key"] = "Value" };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        await Assert.ThrowsAsync<ArgumentNullException>(() => context.EvaluateAsync(null!));
+    }
+
+    [Fact]
+    public async Task EvaluateAsync_WithCancelledToken_ThrowsOperationCanceledException()
+    {
+        Dictionary<string, object> data = new() { ["IsActive"] = true };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+        CancellationToken cancelledToken = new(canceled: true);
+
+        await Assert.ThrowsAsync<OperationCanceledException>(() => context.EvaluateAsync("IsActive", cancelledToken));
+    }
+
+    #endregion
+
+    #region JSON Data
+
+    [Fact]
+    public void Evaluate_WithJsonData_ReturnsCorrectResult()
+    {
+        string json = """{"IsActive": true, "Count": 5}""";
+        IConditionContext context = _evaluator.CreateConditionContext(json);
+
+        Assert.True(context.Evaluate("IsActive"));
+        Assert.True(context.Evaluate("Count > 3"));
+    }
+
+    [Fact]
+    public void Evaluate_WithComplexJsonData_ReturnsCorrectResult()
+    {
+        string json = """
+            {
+                "Customer": {
+                    "Name": "John",
+                    "IsActive": true
+                },
+                "Status": "Active"
+            }
+            """;
+        IConditionContext context = _evaluator.CreateConditionContext(json);
+
+        Assert.True(context.Evaluate("Customer.IsActive"));
+        Assert.True(context.Evaluate("Status = \"Active\""));
+    }
+
+    #endregion
+
+    #region Interface Implementation
+
+    [Fact]
+    public void ConditionContext_ImplementsIConditionContext()
+    {
+        Dictionary<string, object> data = new() { ["Key"] = "Value" };
+        IConditionContext context = _evaluator.CreateConditionContext(data);
+
+        Assert.IsAssignableFrom<IConditionContext>(context);
+    }
+
+    #endregion
+}

--- a/TriasDev.Templify/Conditionals/ConditionContext.cs
+++ b/TriasDev.Templify/Conditionals/ConditionContext.cs
@@ -1,0 +1,63 @@
+// Copyright (c) 2025 TriasDev GmbH & Co. KG
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+using TriasDev.Templify.Core;
+
+namespace TriasDev.Templify.Conditionals;
+
+/// <summary>
+/// Provides a pre-loaded data context for efficient batch evaluation of multiple condition expressions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// This class wraps an evaluation context and provides direct evaluation methods,
+/// eliminating the need to pass the context to each evaluation call.
+/// </para>
+/// <para>
+/// Thread Safety: This class is thread-safe. The underlying evaluator has no mutable
+/// instance state (only immutable constants), so multiple threads can call Evaluate
+/// concurrently without synchronization.
+/// </para>
+/// </remarks>
+/// <example>
+/// <code>
+/// var evaluator = new ConditionEvaluator();
+/// var context = evaluator.CreateConditionContext(data);
+///
+/// bool r1 = context.Evaluate("IsActive");
+/// bool r2 = context.Evaluate("Count > 5");
+/// </code>
+/// </example>
+public sealed class ConditionContext : IConditionContext
+{
+    private readonly ConditionalEvaluator _evaluator;
+    private readonly IEvaluationContext _context;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="ConditionContext"/> class.
+    /// </summary>
+    /// <param name="evaluator">The evaluator to use for condition evaluation.</param>
+    /// <param name="context">The evaluation context containing variable data.</param>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="evaluator"/> or <paramref name="context"/> is null.</exception>
+    internal ConditionContext(ConditionalEvaluator evaluator, IEvaluationContext context)
+    {
+        ArgumentNullException.ThrowIfNull(evaluator);
+        ArgumentNullException.ThrowIfNull(context);
+        _evaluator = evaluator;
+        _context = context;
+    }
+
+    /// <inheritdoc/>
+    public bool Evaluate(string expression)
+    {
+        ArgumentNullException.ThrowIfNull(expression);
+        return _evaluator.Evaluate(expression, _context);
+    }
+
+    /// <inheritdoc/>
+    public Task<bool> EvaluateAsync(string expression, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return Task.FromResult(Evaluate(expression));
+    }
+}

--- a/TriasDev.Templify/Conditionals/ConditionEvaluator.cs
+++ b/TriasDev.Templify/Conditionals/ConditionEvaluator.cs
@@ -121,4 +121,21 @@ public sealed class ConditionEvaluator : IConditionEvaluator
         Dictionary<string, object> data = JsonDataParser.ParseJsonToDataDictionary(jsonData);
         return new GlobalEvaluationContext(data);
     }
+
+    /// <inheritdoc/>
+    public IConditionContext CreateConditionContext(Dictionary<string, object> data)
+    {
+        ArgumentNullException.ThrowIfNull(data);
+        IEvaluationContext context = new GlobalEvaluationContext(data);
+        return new ConditionContext(_evaluator, context);
+    }
+
+    /// <inheritdoc/>
+    public IConditionContext CreateConditionContext(string jsonData)
+    {
+        ArgumentNullException.ThrowIfNull(jsonData);
+        Dictionary<string, object> data = JsonDataParser.ParseJsonToDataDictionary(jsonData);
+        IEvaluationContext context = new GlobalEvaluationContext(data);
+        return new ConditionContext(_evaluator, context);
+    }
 }

--- a/TriasDev.Templify/Conditionals/IConditionContext.cs
+++ b/TriasDev.Templify/Conditionals/IConditionContext.cs
@@ -1,0 +1,59 @@
+// Copyright (c) 2025 TriasDev GmbH & Co. KG
+// Licensed under the MIT License. See LICENSE file in the project root for full license information.
+
+namespace TriasDev.Templify.Conditionals;
+
+/// <summary>
+/// Represents a pre-loaded data context for efficient batch evaluation of multiple condition expressions.
+/// </summary>
+/// <remarks>
+/// <para>
+/// Use this interface when evaluating many conditions against the same data set.
+/// Creating a context once and reusing it is more efficient than parsing data for each evaluation.
+/// </para>
+/// <para>
+/// Create instances via <see cref="IConditionEvaluator.CreateConditionContext(Dictionary{string, object})"/>
+/// or <see cref="IConditionEvaluator.CreateConditionContext(string)"/>.
+/// </para>
+/// </remarks>
+/// <example>
+/// Batch evaluation example:
+/// <code>
+/// var evaluator = new ConditionEvaluator();
+/// var context = evaluator.CreateConditionContext(data);
+///
+/// // Evaluate multiple expressions efficiently against the same data
+/// bool r1 = context.Evaluate("IsActive");
+/// bool r2 = context.Evaluate("Count > 0");
+/// bool r3 = context.Evaluate("Status = \"Active\" and IsEnabled");
+/// </code>
+/// </example>
+public interface IConditionContext
+{
+    /// <summary>
+    /// Evaluates a conditional expression against the pre-loaded data.
+    /// </summary>
+    /// <param name="expression">
+    /// The expression to evaluate. Supports:
+    /// <list type="bullet">
+    /// <item>Simple variables: "IsActive"</item>
+    /// <item>Nested paths: "Customer.Address.City"</item>
+    /// <item>Comparisons: "Status = \"Active\"", "Count > 0"</item>
+    /// <item>Logical operators: "IsEnabled and HasAccess", "A or B"</item>
+    /// <item>Negation: "not IsDisabled"</item>
+    /// </list>
+    /// </param>
+    /// <returns>True if the condition is met; otherwise, false.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="expression"/> is null.</exception>
+    bool Evaluate(string expression);
+
+    /// <summary>
+    /// Asynchronously evaluates a conditional expression against the pre-loaded data.
+    /// </summary>
+    /// <param name="expression">The expression to evaluate.</param>
+    /// <param name="cancellationToken">A token to cancel the operation.</param>
+    /// <returns>A task that resolves to true if the condition is met; otherwise, false.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="expression"/> is null.</exception>
+    /// <exception cref="OperationCanceledException">Thrown when the operation is canceled.</exception>
+    Task<bool> EvaluateAsync(string expression, CancellationToken cancellationToken = default);
+}

--- a/TriasDev.Templify/Conditionals/IConditionEvaluator.cs
+++ b/TriasDev.Templify/Conditionals/IConditionEvaluator.cs
@@ -141,4 +141,38 @@ public interface IConditionEvaluator
     IEvaluationContext CreateContext(string jsonData);
 
     #endregion
+
+    #region CreateConditionContext
+
+    /// <summary>
+    /// Creates a condition context from a data dictionary for efficient batch evaluations.
+    /// </summary>
+    /// <param name="data">The data dictionary containing variables to resolve.</param>
+    /// <returns>A condition context that allows direct evaluation of multiple expressions.</returns>
+    /// <remarks>
+    /// <para>
+    /// Use this method when evaluating multiple expressions against the same data.
+    /// The returned <see cref="IConditionContext"/> provides a cleaner API for batch evaluations.
+    /// </para>
+    /// </remarks>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="data"/> is null.</exception>
+    /// <example>
+    /// <code>
+    /// var context = evaluator.CreateConditionContext(data);
+    /// bool r1 = context.Evaluate("IsActive");
+    /// bool r2 = context.Evaluate("Count > 0");
+    /// </code>
+    /// </example>
+    IConditionContext CreateConditionContext(Dictionary<string, object> data);
+
+    /// <summary>
+    /// Creates a condition context from JSON data for efficient batch evaluations.
+    /// </summary>
+    /// <param name="jsonData">A JSON string representing the data object.</param>
+    /// <returns>A condition context that allows direct evaluation of multiple expressions.</returns>
+    /// <exception cref="ArgumentNullException">Thrown when <paramref name="jsonData"/> is null.</exception>
+    /// <exception cref="System.Text.Json.JsonException">Thrown when JSON is invalid or root is not an object.</exception>
+    IConditionContext CreateConditionContext(string jsonData);
+
+    #endregion
 }


### PR DESCRIPTION
## Summary

Implements #25

- Add `IConditionContext` interface for efficient batch evaluation of multiple condition expressions
- Add `ConditionContext` implementation wrapping evaluator and context
- Add `CreateConditionContext()` methods to `IConditionEvaluator`
- Include `CancellationToken` support in async methods
- Add comprehensive test coverage (22 tests)

## Usage

```csharp
var evaluator = new ConditionEvaluator();
var context = evaluator.CreateConditionContext(data);  // or JSON string

// Efficient batch evaluation - no need to pass evaluator each time
bool r1 = context.Evaluate("IsActive");
bool r2 = context.Evaluate("Count > 0");
bool r3 = await context.EvaluateAsync("Status = \"Active\"");
```

## Test plan

- [x] All 743 tests passing
- [x] New tests for `IConditionContext` interface (22 tests)
- [x] Null validation tests
- [x] CancellationToken tests
- [x] JSON and Dictionary input tests