### PR TITLE
chore: Update SonarQube workflow to use ubuntu-latest runner

### DIFF
--- a/.github/workflows/build-sonarqube.yml
+++ b/.github/workflows/build-sonarqube.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   build:
     name: Build and analyze
-    runs-on: self-hosted
+    runs-on: ubuntu-latest
     env:
       SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
 


### PR DESCRIPTION
## Summary
- Change runner from `self-hosted` to `ubuntu-latest`

## Changes
- Updated `.github/workflows/build-sonarqube.yml` to use GitHub-hosted ubuntu-latest runner

## Benefits
- No self-hosted runner maintenance required
- Standardized, consistent environment
- Managed by GitHub infrastructure
- Better for CI/CD portability

## Test Plan
- [ ] Verify workflow triggers successfully
- [ ] Confirm SonarQube analysis completes
- [ ] Check that all steps execute properly on ubuntu-latest