### PR TITLE
fix: Use SONAR_HOST_URL from secrets instead of variables

### DIFF
--- a/.github/workflows/build-sonarqube.yml
+++ b/.github/workflows/build-sonarqube.yml
@@ -11,7 +11,7 @@ jobs:
     name: Build and analyze
     runs-on: ubuntu-latest
     env:
-      SONAR_HOST_URL: ${{ vars.SONAR_HOST_URL }}
+      SONAR_HOST_URL: ${{ secrets.SONAR_HOST_URL }}
 
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary
- Change `SONAR_HOST_URL` from repository variable to repository secret

## Problem
The workflow is currently failing with error:
```
The format of the analysis property sonar.host.url= is invalid
```

This occurs because `vars.SONAR_HOST_URL` is empty (not configured as a repository variable).

## Solution
Use `secrets.SONAR_HOST_URL` instead, which is more appropriate for configuration values and aligns with how `SONAR_TOKEN` is handled.

## Configuration Required
Ensure both secrets are set in repository settings:
- `SONAR_TOKEN` - Authentication token for SonarQube
- `SONAR_HOST_URL` - URL of the SonarQube server

## Test Plan
- [ ] Verify workflow runs without the "invalid format" error
- [ ] Confirm SonarQube analysis completes successfully
- [ ] Check that analysis results appear in SonarQube dashboard