### PR TITLE
fix: prevent nested paragraphs in RepeatingConverter

### DIFF
--- a/TriasDev.Templify.Converter/Converters/RepeatingConverter.cs
+++ b/TriasDev.Templify.Converter/Converters/RepeatingConverter.cs
@@ -59,18 +59,10 @@ public class RepeatingConverter
         OpenXmlElement? lastMovedElement = OpenXmlHelpers.UnwrapContentControl(sdt);
 
         // Insert {{/foreach}} after the last moved element
-        // To avoid collision with nested loop end markers, always create a new paragraph
+        // Use the helper method to properly handle paragraph boundaries
         if (lastMovedElement != null)
         {
-            // Create a new paragraph with the end marker
-            Paragraph endParagraph = new Paragraph(
-                new Run(
-                    new RunProperties(new Highlight() { Val = HighlightColorValues.Green }),
-                    new Text("{{/foreach}}")
-                )
-            );
-
-            lastMovedElement.InsertAfterSelf(endParagraph);
+            OpenXmlHelpers.InsertTextAfter(lastMovedElement, "{{/foreach}}", HighlightColorValues.Green);
         }
 
         return true;


### PR DESCRIPTION
## Summary

- Use `OpenXmlHelpers.InsertTextAfter()` instead of directly creating a new paragraph for `{{/foreach}}` tags
- Prevents invalid nested paragraph structures when the last moved element is a Run inside an existing paragraph

Fixes #41

## Test plan

- [x] All 766 existing tests pass
- [x] Converted customer template passes OpenXML schema validation
- [x] Verified no nested `<w:p>` elements in converted document