### PR TITLE
fix: evaluate conditionals inside loops with correct context

### DIFF
--- a/TriasDev.Templify.Tests/Integration/ConditionalInLoopTests.cs
+++ b/TriasDev.Templify.Tests/Integration/ConditionalInLoopTests.cs
@@ -343,6 +343,373 @@ public sealed class ConditionalInLoopTests
         Assert.Equal("Only: Single", verifier.GetParagraphText(0));
     }
 
+    /// <summary>
+    /// Regression test for bug where conditionals inside loops were evaluated at global scope
+    /// instead of loop item scope. This caused conditionals to fail when the path exists on
+    /// loop items but not on the global context.
+    /// </summary>
+    /// <remarks>
+    /// Based on customer issue where:
+    /// - Global context has interview.availableItemsByKey.items but WITHOUT certain keys
+    /// - Loop items (itAssets) each have their own interview with the keys
+    /// - Conditional {{#if interview.availableItemsByKey.items.someKey...}} inside loop
+    ///   should evaluate against loop item, not global context
+    /// </remarks>
+    [Fact]
+    public void ProcessTemplate_ConditionalInLoop_UsesLoopItemContext_NotGlobalContext()
+    {
+        // Arrange: Global interview does NOT have the nested path, but loop items DO
+        DocumentBuilder builder = new DocumentBuilder();
+        builder.AddParagraph("{{#foreach process.itAssets.items}}");
+        builder.AddParagraph("{{#if interview.settings.isEnabled}}");
+        builder.AddParagraph("YES");
+        builder.AddParagraph("{{else}}");
+        builder.AddParagraph("NO");
+        builder.AddParagraph("{{/if}}");
+        builder.AddParagraph("{{/foreach}}");
+
+        MemoryStream templateStream = builder.ToStream();
+
+        // Global interview does NOT have settings.isEnabled
+        // But each loop item has its own interview WITH settings.isEnabled = true
+        Dictionary<string, object> data = new Dictionary<string, object>
+        {
+            // Global interview - missing the nested path
+            ["interview"] = new Dictionary<string, object>
+            {
+                ["name"] = "Global Interview"
+                // Note: NO "settings" here - this is the key difference
+            },
+            ["process"] = new Dictionary<string, object>
+            {
+                ["itAssets"] = new Dictionary<string, object>
+                {
+                    ["items"] = new List<object>
+                    {
+                        new Dictionary<string, object>
+                        {
+                            ["name"] = "Asset 1",
+                            // Loop item HAS the nested path
+                            ["interview"] = new Dictionary<string, object>
+                            {
+                                ["settings"] = new Dictionary<string, object>
+                                {
+                                    ["isEnabled"] = true
+                                }
+                            }
+                        },
+                        new Dictionary<string, object>
+                        {
+                            ["name"] = "Asset 2",
+                            ["interview"] = new Dictionary<string, object>
+                            {
+                                ["settings"] = new Dictionary<string, object>
+                                {
+                                    ["isEnabled"] = true
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        DocumentTemplateProcessor processor = new DocumentTemplateProcessor();
+        MemoryStream outputStream = new MemoryStream();
+
+        // Act
+        ProcessingResult result = processor.ProcessTemplate(templateStream, outputStream, data);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        using DocumentVerifier verifier = new DocumentVerifier(outputStream);
+        List<string> paragraphs = verifier.GetAllParagraphTexts();
+
+        // Both items should show "YES" because their interview.settings.isEnabled is true
+        // Bug behavior: Would show "NO" because global interview doesn't have the path
+        Assert.Equal(2, paragraphs.Count);
+        Assert.Equal("YES", paragraphs[0]);
+        Assert.Equal("YES", paragraphs[1]);
+    }
+
+    /// <summary>
+    /// Test inline conditional inside loop also uses loop item context.
+    /// </summary>
+    [Fact]
+    public void ProcessTemplate_InlineConditionalInLoop_UsesLoopItemContext()
+    {
+        // Arrange: Same scenario but with inline conditional (same paragraph)
+        DocumentBuilder builder = new DocumentBuilder();
+        builder.AddParagraph("{{#foreach items}}");
+        builder.AddParagraph("{{#if data.active}}Active{{else}}Inactive{{/if}} - {{name}}");
+        builder.AddParagraph("{{/foreach}}");
+
+        MemoryStream templateStream = builder.ToStream();
+
+        // Global data does NOT have data.active, but loop items DO
+        Dictionary<string, object> data = new Dictionary<string, object>
+        {
+            ["data"] = new Dictionary<string, object>
+            {
+                ["name"] = "Global"
+                // NO "active" field
+            },
+            ["items"] = new List<object>
+            {
+                new Dictionary<string, object>
+                {
+                    ["name"] = "Item1",
+                    ["data"] = new Dictionary<string, object>
+                    {
+                        ["active"] = true
+                    }
+                },
+                new Dictionary<string, object>
+                {
+                    ["name"] = "Item2",
+                    ["data"] = new Dictionary<string, object>
+                    {
+                        ["active"] = false
+                    }
+                }
+            }
+        };
+
+        DocumentTemplateProcessor processor = new DocumentTemplateProcessor();
+        MemoryStream outputStream = new MemoryStream();
+
+        // Act
+        ProcessingResult result = processor.ProcessTemplate(templateStream, outputStream, data);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        using DocumentVerifier verifier = new DocumentVerifier(outputStream);
+        List<string> paragraphs = verifier.GetAllParagraphTexts();
+
+        Assert.Equal(2, paragraphs.Count);
+        Assert.Equal("Active - Item1", paragraphs[0]);
+        Assert.Equal("Inactive - Item2", paragraphs[1]);
+    }
+
+    /// <summary>
+    /// Test conditional in nested loop accessing outer loop's data.
+    /// </summary>
+    [Fact]
+    public void ProcessTemplate_ConditionalInNestedLoop_AccessesOuterLoopData()
+    {
+        // Arrange: Conditional inside inner loop references outer loop's property
+        DocumentBuilder builder = new DocumentBuilder();
+        builder.AddParagraph("{{#foreach categories}}");
+        builder.AddParagraph("Category: {{name}}");
+        builder.AddParagraph("{{#foreach items}}");
+        // Conditional checks OUTER loop's "isPremium" property, not inner item's
+        builder.AddParagraph("{{#if isPremium}}★ {{title}}{{else}}{{title}}{{/if}}");
+        builder.AddParagraph("{{/foreach}}");
+        builder.AddParagraph("{{/foreach}}");
+
+        MemoryStream templateStream = builder.ToStream();
+
+        Dictionary<string, object> data = new Dictionary<string, object>
+        {
+            ["categories"] = new List<object>
+            {
+                new Dictionary<string, object>
+                {
+                    ["name"] = "Premium Category",
+                    ["isPremium"] = true,
+                    ["items"] = new List<object>
+                    {
+                        new Dictionary<string, object> { ["title"] = "Item A" },
+                        new Dictionary<string, object> { ["title"] = "Item B" }
+                    }
+                },
+                new Dictionary<string, object>
+                {
+                    ["name"] = "Standard Category",
+                    ["isPremium"] = false,
+                    ["items"] = new List<object>
+                    {
+                        new Dictionary<string, object> { ["title"] = "Item C" }
+                    }
+                }
+            }
+        };
+
+        DocumentTemplateProcessor processor = new DocumentTemplateProcessor();
+        MemoryStream outputStream = new MemoryStream();
+
+        // Act
+        ProcessingResult result = processor.ProcessTemplate(templateStream, outputStream, data);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        using DocumentVerifier verifier = new DocumentVerifier(outputStream);
+        List<string> paragraphs = verifier.GetAllParagraphTexts();
+
+        // Premium category items get stars
+        Assert.Contains("Category: Premium Category", paragraphs);
+        Assert.Contains("★ Item A", paragraphs);
+        Assert.Contains("★ Item B", paragraphs);
+
+        // Standard category items don't get stars
+        Assert.Contains("Category: Standard Category", paragraphs);
+        Assert.Contains("Item C", paragraphs);
+        Assert.DoesNotContain("★ Item C", paragraphs);
+    }
+
+    /// <summary>
+    /// Test conditional in nested loop accessing global data.
+    /// </summary>
+    [Fact]
+    public void ProcessTemplate_ConditionalInNestedLoop_AccessesGlobalData()
+    {
+        // Arrange: Conditional inside nested loop references GLOBAL property
+        DocumentBuilder builder = new DocumentBuilder();
+        builder.AddParagraph("{{#foreach orders}}");
+        builder.AddParagraph("Order: {{id}}");
+        builder.AddParagraph("{{#foreach items}}");
+        // Conditional checks GLOBAL "showPrices" setting
+        builder.AddParagraph("{{#if showPrices}}{{name}}: ${{price}}{{else}}{{name}}{{/if}}");
+        builder.AddParagraph("{{/foreach}}");
+        builder.AddParagraph("{{/foreach}}");
+
+        MemoryStream templateStream = builder.ToStream();
+
+        Dictionary<string, object> data = new Dictionary<string, object>
+        {
+            ["showPrices"] = true, // Global setting
+            ["orders"] = new List<object>
+            {
+                new Dictionary<string, object>
+                {
+                    ["id"] = "ORD-001",
+                    ["items"] = new List<object>
+                    {
+                        new Dictionary<string, object> { ["name"] = "Widget", ["price"] = 10 },
+                        new Dictionary<string, object> { ["name"] = "Gadget", ["price"] = 20 }
+                    }
+                }
+            }
+        };
+
+        DocumentTemplateProcessor processor = new DocumentTemplateProcessor();
+        MemoryStream outputStream = new MemoryStream();
+
+        // Act
+        ProcessingResult result = processor.ProcessTemplate(templateStream, outputStream, data);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        using DocumentVerifier verifier = new DocumentVerifier(outputStream);
+        List<string> paragraphs = verifier.GetAllParagraphTexts();
+
+        Assert.Contains("Order: ORD-001", paragraphs);
+        Assert.Contains("Widget: $10", paragraphs);
+        Assert.Contains("Gadget: $20", paragraphs);
+    }
+
+    /// <summary>
+    /// Test deeply nested path resolution in loop context (like customer's interview structure).
+    /// </summary>
+    [Fact]
+    public void ProcessTemplate_DeeplyNestedPathInLoopConditional_Works()
+    {
+        // Arrange: Mimics customer's interview.availableItemsByKey.items.someKey.answers... structure
+        DocumentBuilder builder = new DocumentBuilder();
+        builder.AddParagraph("{{#foreach assets}}");
+        builder.AddParagraph("{{#if interview.availableItemsByKey.items.question1.answers.yes.selected}}Ja{{else}}Nein{{/if}}");
+        builder.AddParagraph("{{/foreach}}");
+
+        MemoryStream templateStream = builder.ToStream();
+
+        Dictionary<string, object> data = new Dictionary<string, object>
+        {
+            // Global interview has different structure (no question1)
+            ["interview"] = new Dictionary<string, object>
+            {
+                ["availableItemsByKey"] = new Dictionary<string, object>
+                {
+                    ["items"] = new Dictionary<string, object>
+                    {
+                        ["otherQuestion"] = new Dictionary<string, object>
+                        {
+                            ["answers"] = new Dictionary<string, object>()
+                        }
+                    }
+                }
+            },
+            ["assets"] = new List<object>
+            {
+                // Loop item 1: question1 selected = true
+                new Dictionary<string, object>
+                {
+                    ["interview"] = new Dictionary<string, object>
+                    {
+                        ["availableItemsByKey"] = new Dictionary<string, object>
+                        {
+                            ["items"] = new Dictionary<string, object>
+                            {
+                                ["question1"] = new Dictionary<string, object>
+                                {
+                                    ["answers"] = new Dictionary<string, object>
+                                    {
+                                        ["yes"] = new Dictionary<string, object>
+                                        {
+                                            ["selected"] = true
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                },
+                // Loop item 2: question1 selected = false
+                new Dictionary<string, object>
+                {
+                    ["interview"] = new Dictionary<string, object>
+                    {
+                        ["availableItemsByKey"] = new Dictionary<string, object>
+                        {
+                            ["items"] = new Dictionary<string, object>
+                            {
+                                ["question1"] = new Dictionary<string, object>
+                                {
+                                    ["answers"] = new Dictionary<string, object>
+                                    {
+                                        ["yes"] = new Dictionary<string, object>
+                                        {
+                                            ["selected"] = false
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        };
+
+        DocumentTemplateProcessor processor = new DocumentTemplateProcessor();
+        MemoryStream outputStream = new MemoryStream();
+
+        // Act
+        ProcessingResult result = processor.ProcessTemplate(templateStream, outputStream, data);
+
+        // Assert
+        Assert.True(result.IsSuccess);
+
+        using DocumentVerifier verifier = new DocumentVerifier(outputStream);
+        List<string> paragraphs = verifier.GetAllParagraphTexts();
+
+        Assert.Equal(2, paragraphs.Count);
+        Assert.Equal("Ja", paragraphs[0]);   // First item has selected=true
+        Assert.Equal("Nein", paragraphs[1]); // Second item has selected=false
+    }
+
     // Helper classes for test data
     private class Order
     {


### PR DESCRIPTION
## Summary

- Fix bug where conditionals inside loops were evaluated at wrong scope
- Add regression tests for conditionals in nested loops
- Add documentation about variable resolution order and shadowing

## Problem

Conditionals inside loop blocks were being evaluated at the **global context** instead of the **loop iteration context**. This caused conditionals to fail when referencing paths that exist on loop items but not in the global context.

**Example:**
```
{{#foreach process.itAssets.items}}
  {{#if interview.settings.isEnabled}}YES{{else}}NO{{/if}}
{{/foreach}}
```

- Global `interview` does NOT have `settings.isEnabled` → condition evaluated as `false`
- Loop item HAS `interview.settings.isEnabled = true` → should evaluate as `true`

**Before:** `NO` (wrong - used global context)
**After:** `YES` (correct - uses loop item context)

## Solution

Modified `DocumentWalker.WalkElements` to:
1. Pre-detect loops before processing conditionals
2. Skip conditionals whose start element is inside a loop block
3. Let those conditionals be processed when the loop expands with `LoopEvaluationContext`

## Changes

| File | Description |
|------|-------------|
| `DocumentWalker.cs` | Skip conditionals inside loops at document level |
| `ConditionalInLoopTests.cs` | Add 5 regression tests for nested loop scenarios |
| `ConditionalEvaluatorTests.cs` | Add 3 unit tests for deep nested paths |
| `docs/for-template-authors/loops.md` | Document variable resolution order and shadowing |

## Test plan

- [x] All 859 tests pass
- [x] New regression tests cover the bug scenario
- [x] Documentation explains variable resolution behavior
- [x] Code formatting verified

Closes #59