### PR TITLE
chore: prepare release v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.0] - 2026-02-13
+
+### Added
+- **DocumentProperties Option** - Set document metadata properties on the output document (#77)
+  - `Author`, `Title`, `Subject`, `Description`, `Keywords`, `Category`, `LastModifiedBy`
+  - Null properties preserve original template values; non-null values overwrite
+  - Configure via `PlaceholderReplacementOptions.DocumentProperties`
+- **Custom Templify Icon and Branding** - New icon for the library, GUI, and documentation (#76)
+
+### Improved
+- Test coverage increased to 972 tests
+
 ## [1.4.2] - 2026-02-09
 
 ### Fixed

--- a/TriasDev.Templify/TriasDev.Templify.csproj
+++ b/TriasDev.Templify/TriasDev.Templify.csproj
@@ -11,7 +11,7 @@
 
     <!-- NuGet Package Metadata -->
     <PackageId>TriasDev.Templify</PackageId>
-    <Version>1.4.2</Version>
+    <Version>1.5.0</Version>
     <Authors>TriasDev GmbH &amp; Co. KG</Authors>
     <Company>TriasDev GmbH &amp; Co. KG</Company>
     <Description>High-performance templating engine for .NET. Process Word documents (.docx) and plain text templates with the same powerful syntax. Replace placeholders, evaluate conditionals, and process loops without Microsoft Word. Built on OpenXML SDK with 100% test coverage.</Description>
@@ -23,7 +23,7 @@
     <PackageTags>word;docx;template;openxml;document-generation;templating;word-documents;office;dotnet;email;text-templates</PackageTags>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageReleaseNotes>v1.4.2: Fix case-insensitive boolean comparison in ConditionalEvaluator - boolean values like True/False/TRUE/FALSE are now correctly compared regardless of case, while preserving case-sensitive string comparisons.</PackageReleaseNotes>
+    <PackageReleaseNotes>v1.5.0: Add DocumentProperties option for setting document metadata (Author, Title, Subject, Description, Keywords, Category, LastModifiedBy) on output documents. Custom Templify icon and branding.</PackageReleaseNotes>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary

- Bump version to 1.5.0
- Update CHANGELOG.md with new features since v1.4.2
- Update PackageReleaseNotes

### Changes since v1.4.2
- **DocumentProperties option** for setting document metadata (#77, #78)
- **Custom Templify icon and branding** (#76)
- 972 tests passing