### PR TITLE
chore: add Dependabot for NuGet and GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,41 @@
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Vienna"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+      - "nuget"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+    groups:
+      nuget-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "06:00"
+      timezone: "Europe/Vienna"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "ci"
+      include: "scope"
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` enabling weekly dependency updates for NuGet and GitHub Actions
- Group minor/patch updates into a single PR per ecosystem; major updates open separately
- Commit prefixes (`chore` / `ci`) align with release-please conventions

## Test plan
- [ ] Verify Dependabot runs on the next scheduled cycle (or trigger manually via repo Insights → Dependency graph → Dependabot)
- [ ] Confirm grouped PRs appear with correct labels (`dependencies`, `nuget` / `github-actions`)