### PR TITLE
chore: migrate GUI to Avalonia 12

### DIFF
--- a/TriasDev.Templify.Gui/App.axaml.cs
+++ b/TriasDev.Templify.Gui/App.axaml.cs
@@ -2,11 +2,8 @@
 // Licensed under the MIT License. See LICENSE file in the project root for full license information.
 
 using System;
-using System.Linq;
 using Avalonia;
 using Avalonia.Controls.ApplicationLifetimes;
-using Avalonia.Data.Core;
-using Avalonia.Data.Core.Plugins;
 using Avalonia.Markup.Xaml;
 using Microsoft.Extensions.DependencyInjection;
 using TriasDev.Templify.Gui.Services;
@@ -28,11 +25,6 @@ public partial class App : Application
     {
         if (ApplicationLifetime is IClassicDesktopStyleApplicationLifetime desktop)
         {
-            // Avoid duplicate validations from both Avalonia and the CommunityToolkit.
-            // More info: https://docs.avaloniaui.net/docs/guides/development-guides/data-validation#manage-validationplugins
-            DisableAvaloniaDataAnnotationValidation();
-
-            // Create MainWindow first
             MainWindow mainWindow = new MainWindow();
             desktop.MainWindow = mainWindow;
 
@@ -72,18 +64,5 @@ public partial class App : Application
 
             throw new InvalidOperationException("MainWindow not available for FileDialogService");
         });
-    }
-
-    private void DisableAvaloniaDataAnnotationValidation()
-    {
-        // Get an array of plugins to remove
-        DataAnnotationsValidationPlugin[] dataValidationPluginsToRemove =
-            BindingPlugins.DataValidators.OfType<DataAnnotationsValidationPlugin>().ToArray();
-
-        // remove each entry found
-        foreach (DataAnnotationsValidationPlugin plugin in dataValidationPluginsToRemove)
-        {
-            BindingPlugins.DataValidators.Remove(plugin);
-        }
     }
 }

--- a/TriasDev.Templify.Gui/TriasDev.Templify.Gui.csproj
+++ b/TriasDev.Templify.Gui/TriasDev.Templify.Gui.csproj
@@ -14,12 +14,12 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="11.3.10" />
-    <PackageReference Include="Avalonia.Desktop" Version="11.3.10" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="11.3.10" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="11.3.10" />
-    <!--Condition below is needed to remove Avalonia.Diagnostics package from build output in Release configuration.-->
-    <PackageReference Include="Avalonia.Diagnostics" Version="11.3.10">
+    <PackageReference Include="Avalonia" Version="12.0.3" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.3" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.3" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.3" />
+    <!--Avalonia 12 replaces Avalonia.Diagnostics with AvaloniaUI.DiagnosticsSupport (bridge to external DevTools, F12).-->
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>

--- a/TriasDev.Templify.Gui/Views/MainWindow.axaml
+++ b/TriasDev.Templify.Gui/Views/MainWindow.axaml
@@ -30,7 +30,7 @@
             <TextBox Grid.Column="1"
                      Text="{Binding TemplatePath}"
                      IsReadOnly="True"
-                     Watermark="Select a .docx template file"
+                     PlaceholderText="Select a .docx template file"
                      Margin="10,0,10,0"/>
             <Button Grid.Column="2"
                     Content="Browse..."
@@ -43,7 +43,7 @@
             <TextBox Grid.Column="1"
                      Text="{Binding JsonPath}"
                      IsReadOnly="True"
-                     Watermark="Select a .json data file"
+                     PlaceholderText="Select a .json data file"
                      Margin="10,0,10,0"/>
             <Button Grid.Column="2"
                     Content="Browse..."
@@ -56,7 +56,7 @@
             <TextBox Grid.Column="1"
                      Text="{Binding OutputPath}"
                      IsReadOnly="True"
-                     Watermark="Output will be saved here"
+                     PlaceholderText="Output will be saved here"
                      Margin="10,0,10,0"/>
             <Button Grid.Column="2"
                     Content="Browse..."


### PR DESCRIPTION
## Summary

- Bumps all Avalonia packages (`Avalonia`, `Avalonia.Desktop`, `Avalonia.Themes.Fluent`, `Avalonia.Fonts.Inter`) from `11.3.10` to `12.0.3` in sync.
- Removes obsolete `DisableAvaloniaDataAnnotationValidation()` — `BindingPlugins` is no longer publicly configurable in Avalonia 12, and the DataAnnotations plugin is disabled by default.
- Replaces `Avalonia.Diagnostics` with `AvaloniaUI.DiagnosticsSupport 2.2.1`, the v12 bridge to the external DevTools process (no 12.x `Avalonia.Diagnostics` exists on NuGet).
- Renames `TextBox.Watermark` → `PlaceholderText` in `MainWindow.axaml` (Watermark is obsolete in v12).

Closes #104. Supersedes #100, #101, #102 (which each bumped only a subset of Avalonia packages and broke the build).

## Test plan

- [x] `dotnet build` — clean, 0 warnings, 0 errors
- [x] `dotnet test` — 1126/1126 passed
- [x] `dotnet format --verify-no-changes` — clean
- [ ] CI matrix (Win/Mac/Linux × .NET 6/8/9/10) green
- [ ] Manual smoke test of GUI app

## Follow-up

After merge, group `Avalonia*` packages in `dependabot.yml` so future bumps land in a single PR instead of three split PRs.