### PR TITLE
chore(deps): batch dependency updates (Dependabot aggregation)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
 
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest' && matrix.dotnet-version == '10.0.x'
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v6
         with:
           files: '**/coverage.cobertura.xml'
           fail_ci_if_error: false
@@ -82,7 +82,7 @@ jobs:
         run: dotnet pack TriasDev.Templify/TriasDev.Templify.csproj --no-build --configuration Release --output ./artifacts
 
       - name: Upload NuGet package artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-package
           path: ./artifacts/*.nupkg

--- a/.github/workflows/documentation.yml
+++ b/.github/workflows/documentation.yml
@@ -41,10 +41,10 @@ jobs:
         run: mkdocs build
 
       - name: Setup Pages
-        uses: actions/configure-pages@v4
+        uses: actions/configure-pages@v6
 
       - name: Upload artifact
-        uses: actions/upload-pages-artifact@v3
+        uses: actions/upload-pages-artifact@v5
         with:
           path: 'site'
 
@@ -57,4 +57,4 @@ jobs:
     steps:
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -59,7 +59,7 @@ jobs:
             --skip-duplicate
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-packages
           path: ./artifacts/*.nupkg

--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -79,7 +79,7 @@ jobs:
             --skip-duplicate
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: nuget-packages
           path: ./artifacts/*.nupkg

--- a/TriasDev.Templify.Gui/TriasDev.Templify.Gui.csproj
+++ b/TriasDev.Templify.Gui/TriasDev.Templify.Gui.csproj
@@ -14,17 +14,17 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Avalonia" Version="12.0.3" />
-    <PackageReference Include="Avalonia.Desktop" Version="12.0.3" />
-    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.3" />
-    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.3" />
+    <PackageReference Include="Avalonia" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Desktop" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Themes.Fluent" Version="12.0.5" />
+    <PackageReference Include="Avalonia.Fonts.Inter" Version="12.0.5" />
     <!--Avalonia 12 replaces Avalonia.Diagnostics with AvaloniaUI.DiagnosticsSupport (bridge to external DevTools, F12).-->
-    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.1">
+    <PackageReference Include="AvaloniaUI.DiagnosticsSupport" Version="2.2.3">
       <IncludeAssets Condition="'$(Configuration)' != 'Debug'">None</IncludeAssets>
       <PrivateAssets Condition="'$(Configuration)' != 'Debug'">All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/TriasDev.Templify.Tests/TriasDev.Templify.Tests.csproj
+++ b/TriasDev.Templify.Tests/TriasDev.Templify.Tests.csproj
@@ -13,7 +13,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="DocumentFormat.OpenXml" Version="3.5.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary

Aggregates all open Dependabot update PRs into **one** change so CI runs once instead of once per PR (and again per merge to `main`). Prep step before the 1.6.2 release.

## NuGet updates (supersedes #116)

| Package | From | To |
|---|---|---|
| Avalonia (+ Desktop, Themes.Fluent, Fonts.Inter) | 12.0.3 | 12.0.5 |
| AvaloniaUI.DiagnosticsSupport | 2.2.1 | 2.2.3 |
| Microsoft.Extensions.DependencyInjection | 10.0.8 | 10.0.9 |
| Microsoft.NET.Test.Sdk | 18.5.1 | 18.7.0 |

## GitHub Actions updates

| Action | From | To | Supersedes |
|---|---|---|---|
| codecov/codecov-action | v4 | v6 | #111 |
| actions/upload-artifact | v4 | v7 | #108 |
| actions/upload-pages-artifact | v3 | v5 | #110 |
| actions/configure-pages | v4 | v6 | #109 |
| actions/deploy-pages | v4 | v5 | #107 |

## Verification (local)

- `dotnet restore` — pulls the new versions
- `dotnet build -c Release` — 0 errors
- `dotnet test` — **1130/1130 passing**

## Closes

Closes #107, #108, #109, #110, #111, #116 — Dependabot will auto-close these once their bumps land on `main`.
